### PR TITLE
Feature/kjb/places service

### DIFF
--- a/src/angularjs/src/app/components/places.service.js
+++ b/src/angularjs/src/app/components/places.service.js
@@ -1,0 +1,66 @@
+/**
+ * @ngdoc service
+ * @name pfb.components.Places:Places
+ *
+ * @description
+ * Wrapper to get and compose the parts needed for place views (neighborhood, job info, results)
+ */
+(function() {
+    'use strict';
+
+    /* @ngInject */
+    function Places($q, $log, Neighborhood, AnalysisJob) {
+
+        var module = {
+            getPlace: getPlace
+        };
+
+        return module;
+
+        function getPlace(uuid) {
+            var dfd = $q.defer();
+            if (!uuid) {
+                dfd.resolve({});
+                return dfd.promise;
+            }
+
+            var place = {};
+            Neighborhood.query({uuid: uuid}).$promise.then(function(data) {
+                place.neighborhood = new Neighborhood(data);
+            });
+
+            AnalysisJob.query({neighborhood: uuid, latest: 'True'}).$promise.then(function(data) {
+                if (!data.results || !data.results.length) {
+                    $log.warn('no matching analysis job found for neighborhood ' + uuid);
+                    dfd.resolve({});
+                    return dfd.promise;
+                }
+
+                var lastJob = new AnalysisJob(data.results[0]);
+                place.lastJob = lastJob;
+
+                AnalysisJob.results({uuid: lastJob.uuid}).$promise.then(function(results) {
+                    if (!results.overall_scores) {
+                        $log.warn('no job results found for neighborhood ' + lastJob.uuid);
+                        dfd.resolve({});
+                        return dfd.promise;
+                    }
+
+                    // sort alphabetically by metric name so they will line up by row
+                    place.jobResults = _(results.overall_scores).map(function(obj, key) {
+                        return {
+                            metric: key.replace(/_/g, ' '),
+                            score: obj.score_normalized
+                        };
+                    }).sortBy(function(result) { return result.metric; }).value();
+
+                    dfd.resolve(place);
+                });
+            });
+            return dfd.promise;
+        }
+    }
+
+    angular.module('pfb.components')
+        .factory('Places', Places);
+})();

--- a/src/angularjs/src/app/components/places.service.js
+++ b/src/angularjs/src/app/components/places.service.js
@@ -46,8 +46,10 @@
                         return dfd.promise;
                     }
 
+                    place.results = results;
+
                     // sort alphabetically by metric name so they will line up by row
-                    place.jobResults = _(results.overall_scores).map(function(obj, key) {
+                    place.scores = _(results.overall_scores).map(function(obj, key) {
                         return {
                             metric: key.replace(/_/g, ' '),
                             score: obj.score_normalized

--- a/src/angularjs/src/app/places/compare/compare.controller.js
+++ b/src/angularjs/src/app/places/compare/compare.controller.js
@@ -10,22 +10,21 @@
     'use strict';
 
     /** @ngInject */
-    function CompareController($stateParams, Neighborhood, AnalysisJob, $log, $q, $state) {
+    function CompareController($stateParams, Neighborhood, AnalysisJob, Places, $log, $q, $state) {
         var ctl = this;
 
         initialize();
 
         function initialize() {
             ctl.places = new Array(3);
-            ctl.getPlace = getPlace;
             ctl.clearSelection = clearSelection;
 
             getPlaces([$stateParams.place1, $stateParams.place2, $stateParams.place3]);
         }
 
         function getPlaces(uuids) {
-            var promises = _.map(uuids, function(uuid, offset) {
-                return getPlace(offset, uuid);
+            var promises = _.map(uuids, function(uuid) {
+                return Places.getPlace(uuid);
             });
 
             // do not display any place until all places have been retrieved
@@ -36,49 +35,6 @@
                 $log.error(error);
                 ctl.places = new Array(3);
             });
-        }
-
-        function getPlace(num, uuid) {
-            var dfd = $q.defer();
-            if (!uuid) {
-                dfd.resolve({});
-                return dfd.promise;
-            }
-
-            var place = {};
-            Neighborhood.query({uuid: uuid}).$promise.then(function(data) {
-                place.neighborhood = new Neighborhood(data);
-            });
-
-            AnalysisJob.query({neighborhood: uuid, latest: 'True'}).$promise.then(function(data) {
-                if (!data.results || !data.results.length) {
-                    $log.warn('no matching analysis job found for neighborhood ' + uuid);
-                    dfd.resolve({});
-                    return dfd.promise;
-                }
-
-                var lastJob = new AnalysisJob(data.results[0]);
-                place.lastJob = lastJob;
-
-                AnalysisJob.results({uuid: lastJob.uuid}).$promise.then(function(results) {
-                    if (!results.overall_scores) {
-                        $log.warn('no job results found for neighborhood ' + lastJob.uuid);
-                        dfd.resolve({});
-                        return dfd.promise;
-                    }
-
-                    // sort alphabetically by metric name so they will line up by row
-                    place.jobResults = _(results.overall_scores).map(function(obj, key) {
-                        return {
-                            metric: key.replace(/_/g, ' '),
-                            score: obj.score_normalized
-                        };
-                    }).sortBy(function(result) { return result.metric; }).value();
-
-                    dfd.resolve(place);
-                });
-            });
-            return dfd.promise;
         }
 
         function clearSelection(num) {

--- a/src/angularjs/src/app/places/compare/compare.html
+++ b/src/angularjs/src/app/places/compare/compare.html
@@ -32,7 +32,7 @@
                     <div class="card-map">s
                         <pfb-thumbnail-map></pfb-thumbnail-map>
                     </div>
-                    <ul class="metric-list" ng-repeat="result in place.jobResults">
+                    <ul class="metric-list" ng-repeat="result in place.scores">
                         <li>{{result.metric}}
                             <span class="network-score small">{{result.score | number:0}}</span>
                         </li>

--- a/src/angularjs/src/app/places/detail/places-detail.controller.js
+++ b/src/angularjs/src/app/places/detail/places-detail.controller.js
@@ -10,7 +10,7 @@
     'use strict';
 
     /** @ngInject */
-    function PlaceDetailController($stateParams, Neighborhood, AnalysisJob, Places) {
+    function PlaceDetailController($stateParams, $log, Neighborhood, AnalysisJob, Places) {
         var ctl = this;
 
         var downloadOptions = [
@@ -23,12 +23,7 @@
         initialize();
 
         function initialize() {
-            ctl.place = null;
-            ctl.lastJobScore = null;
-            ctl.scores = null;
-            ctl.mapLayers = {};
-
-            ctl.downloads = null;
+            clearPlace();  // serves to initialize to empty values
 
             getPlace($stateParams.uuid);
         }
@@ -50,7 +45,18 @@
                     ctl.scores = null;
                     ctl.downloads = null;
                 }
+            }).catch(function () {
+                $log.warn("could not load place", uuid);
+                clearPlace();
             });
+        }
+
+        function clearPlace() {
+            ctl.place = null;
+            ctl.lastJobScore = null;
+            ctl.scores = null;
+            ctl.mapLayers = {};
+            ctl.downloads = null;
         }
     }
 

--- a/src/angularjs/src/app/places/detail/places-detail.html
+++ b/src/angularjs/src/app/places/detail/places-detail.html
@@ -58,7 +58,7 @@
                 </div>
             </div>
         </section>
-        <ul class="metric-list" ng-repeat="result in placeDetail.jobResults">
+        <ul class="metric-list" ng-repeat="result in placeDetail.scores">
             <li>{{result.metric}}
                 <div class="tooltip" title="This is a tooltip "><i class="icon-info-circled"></i></div>
                 <span class="network-score small">{{result.score | number:0}}</span>


### PR DESCRIPTION
The comment that I wrote then apparently accidentally threw away on https://github.com/azavea/pfb-network-connectivity/pull/347 was to the effect that the `getPlace` function was very repetitive of the one in the places detail controller.

Because I felt a little bad about requesting a change of that scale in the first place, and even worse about the thought of not requesting initially and then coming back with it on a second round, and to prove to myself that what I was envisioning wasn't crazy, I've made this sub-PR.  It should leave both the compare and place detail views working the same, but with the `getPlaces` function abstracted and shared.